### PR TITLE
Replace deprecated constructor method in widget.

### DIFF
--- a/lib/form-designer/widget-form-designer.php
+++ b/lib/form-designer/widget-form-designer.php
@@ -25,7 +25,7 @@ class CTCT_Form_Designer_Widget extends WP_Widget {
 		);
 
         /* Create the widget. */
-        $this->WP_Widget('CTCT_Form_Designer_Widget', __('Constant Contact Form Designer Widget', 'ctct'), $widget_options, array('width'=>690));
+        parent::__construct('CTCT_Form_Designer_Widget', __('Constant Contact Form Designer Widget', 'ctct'), $widget_options, array('width'=>690));
 
         add_action('wp_print_styles', array(&$this, 'print_styles'));
     }


### PR DESCRIPTION
Fix a notice triggered by the plugin since WordPress 4.3.

Notice: The called constructor method for WP_Widget is deprecated since version 4.3.0!
Use __construct() instead.